### PR TITLE
Alert Feed Tweaks

### DIFF
--- a/app/controllers/alert_feed_items_controller.rb
+++ b/app/controllers/alert_feed_items_controller.rb
@@ -2,7 +2,7 @@ class AlertFeedItemsController < ApplicationController
   include AlertFeedItemsConcerns
 
   def index
-    region = Region.find(params[:region_id])
+    region = Region.find_by(region_identifier: params[:region_id])
     items = region.alert_feed_items.where(condition_filters(params))
     render json: items.to_json
   end

--- a/app/controllers/alert_feed_items_controller.rb
+++ b/app/controllers/alert_feed_items_controller.rb
@@ -3,7 +3,7 @@ class AlertFeedItemsController < ApplicationController
 
   def index
     region = Region.find_by(region_identifier: params[:region_id])
-    items = region.alert_feed_items.where(condition_filters(params))
+    items = region.alert_feed_items.where(condition_filters(params)).limit(20)
     render json: items.to_json
   end
 end

--- a/app/controllers/alert_feeds_controller.rb
+++ b/app/controllers/alert_feeds_controller.rb
@@ -2,7 +2,8 @@ class AlertFeedsController < ApplicationController
   include AlertFeedItemsConcerns
 
   def index
-    feeds = AlertFeed.where(region_id: params[:region_id])
+    region = Region.find_by(region_identifier: params[:region_id])
+    feeds = region.alert_feeds
     render json: feeds.to_json
   end
 

--- a/app/models/region.rb
+++ b/app/models/region.rb
@@ -1,5 +1,12 @@
 require_dependency 'oba/server'
 
+# Confusingly, the ids that are passed in to identify
+# regions are the id values present in the multiregion
+# file: http://regions.onebusaway.org/regions-v3.json
+# These values are referred to as `region_identifier`.
+#
+# The ids that exist locally, in Rails's DB, are
+# more or less unused.
 class Region < ApplicationRecord
   validates_presence_of :api_url, :web_url, :name
   validates_numericality_of :region_identifier

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,14 @@ Rails.application.routes.draw do
   root to: 'regions#index'
 
   resources :alert_feeds, only: [:show]
+
+  # Confusingly, the ids that are passed in to identify
+  # regions are the id values present in the multiregion
+  # file: http://regions.onebusaway.org/regions-v3.json
+  # These values are referred to as `region_identifier`.
+  #
+  # The ids that exist locally, in Rails's DB, are
+  # more or less unused.
   resources :regions, only: [:index, :show] do
     resources :alert_feeds, only: [:index]
     resources :alert_feed_items, only: [:index]


### PR DESCRIPTION
Updates Region IDs used in Alert Feed controllers to match Multiregion file

Confusingly, the ids that are passed in to identify regions are the id values present in the multiregion file: http://regions.onebusaway.org/regions-v3.json. These values are referred to as `region_identifier`. The ids that exist locally, in Rails's DB, are more or less unused.

-----

Limits returned alert feed items count to 20 - Apply a limit to the number of returned feed items so that we don’t send hundreds of alerts to the user the first time they download the list