### PR TITLE
Improve error handling in the StopsController

### DIFF
--- a/app/controllers/stops_controller.rb
+++ b/app/controllers/stops_controller.rb
@@ -1,12 +1,12 @@
 class StopsController < ApplicationController
 
   def show
-    @region = Region.find_by(region_identifier: params[:region_id])
+    @region = Region.find_by!(region_identifier: params[:region_id])
     redirect_to File.join(@region.web_url, "/where/standard/stop.action?id=#{params[:id]}")
   end
 
   def arrivals
-    @region = Region.find_by(region_identifier: params[:region_id])
+    @region = Region.find_by!(region_identifier: params[:region_id])
     @stop_id = params[:stop_id]
     @trip_id = params[:trip_id]
     @service_date = params[:service_date]

--- a/spec/controllers/stops_controller_spec.rb
+++ b/spec/controllers/stops_controller_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe StopsController, type: :controller do
+
+  context 'given a region that exists' do
+    let(:region_identifier) { "808" }
+    let(:region) { double("region", region_identifier: region_identifier, web_url: 'http://example.com/region_test_url/') }
+    before(:each) do
+      expect(Region).to receive(:find_by!).with(region_identifier: region_identifier).and_return(region)
+    end
+
+    describe 'GET arrivals' do
+      subject { get(:arrivals, params: {region_id: region_identifier, stop_id: '123', trip_id: '456', service_date: '1234567890', stop_sequence: 3}) }
+      it "redirects the caller to the arrivals web url for the specified region" do
+        expect(subject).to redirect_to("http://example.com/region_test_url/where/standard/trip.action?id=456&serviceDate=1234567890&showVehicleId=true&stopID=123&stopSequence=3")
+      end
+    end
+  end
+
+  context "given a region that does not exist" do
+    let(:nonexistent) { "999" }
+    describe 'GET arrivals' do
+      subject { get(:arrivals, params: {region_id: nonexistent, stop_id: '123', trip_id: '456', service_date: '1234567890', stop_sequence: 3}) }
+      it "redirects the caller to the arrivals web url for the specified region" do
+        expect { subject.status }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #8 - error: `undefined method web_url for nil:NilClass`

* Add spec validating StopsController#arrivals
* Change `.find_by` calls to `.find_by!` in order to raise `ActiveRecord::RecordNotFound` errors, which will—in turn—trigger a 404 status code.