### PR TITLE
Removes the deprecated `arrivals` endpoint

### DIFF
--- a/app/controllers/stops_controller.rb
+++ b/app/controllers/stops_controller.rb
@@ -5,7 +5,7 @@ class StopsController < ApplicationController
     redirect_to File.join(@region.web_url, "/where/standard/stop.action?id=#{params[:id]}")
   end
 
-  def arrivals
+  def trips
     @region = Region.find_by!(region_identifier: params[:region_id])
     @stop_id = params[:stop_id]
     @trip_id = params[:trip_id]
@@ -22,9 +22,5 @@ class StopsController < ApplicationController
 
     path = "/where/standard/trip.action?#{web_params.to_param}"
     redirect_to File.join(@region.web_url, path)
-  end
-
-  def trips
-    arrivals
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,6 @@ Rails.application.routes.draw do
     resources :alert_feeds, only: [:index]
     resources :alert_feed_items, only: [:index]
     resources :stops, only: [:show] do
-      get 'arrivals'
       get 'trips'
     end
     resources :alarms, only: [:create, :destroy] do

--- a/spec/controllers/stops_controller_spec.rb
+++ b/spec/controllers/stops_controller_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe StopsController, type: :controller do
       expect(Region).to receive(:find_by!).with(region_identifier: region_identifier).and_return(region)
     end
 
-    describe 'GET arrivals' do
-      subject { get(:arrivals, params: {region_id: region_identifier, stop_id: '123', trip_id: '456', service_date: '1234567890', stop_sequence: 3}) }
-      it "redirects the caller to the arrivals web url for the specified region" do
+    describe 'GET trips' do
+      subject { get(:trips, params: {region_id: region_identifier, stop_id: '123', trip_id: '456', service_date: '1234567890', stop_sequence: 3}) }
+      it "redirects the caller to the trips web url for the specified region" do
         expect(subject).to redirect_to("http://example.com/region_test_url/where/standard/trip.action?id=456&serviceDate=1234567890&showVehicleId=true&stopID=123&stopSequence=3")
       end
     end
@@ -19,9 +19,9 @@ RSpec.describe StopsController, type: :controller do
 
   context "given a region that does not exist" do
     let(:nonexistent) { "999" }
-    describe 'GET arrivals' do
-      subject { get(:arrivals, params: {region_id: nonexistent, stop_id: '123', trip_id: '456', service_date: '1234567890', stop_sequence: 3}) }
-      it "redirects the caller to the arrivals web url for the specified region" do
+    describe 'GET trips' do
+      subject { get(:trips, params: {region_id: nonexistent, stop_id: '123', trip_id: '456', service_date: '1234567890', stop_sequence: 3}) }
+      it "redirects the caller to the trips web url for the specified region" do
         expect { subject.status }.to raise_error(ActiveRecord::RecordNotFound)
       end
     end


### PR DESCRIPTION
Fixes #1 - Remove deprecated `arrivals` endpoint

It isn’t being used any more, and should be deleted. It’s been replaced by `trips`