### PR TITLE
Add Delete Functionality for Questions in Admin Panel

### DIFF
--- a/app/controllers/admins/questions_controller.rb
+++ b/app/controllers/admins/questions_controller.rb
@@ -50,7 +50,7 @@ class Admins::QuestionsController < ApplicationController
   def destroy
     @question = @survey.questions.find(params[:id])
     @question.destroy
-    redirect_to admin_study_survey_path(@study, @survey), notice: 'Question was deleted.'
+    redirect_to admin_study_survey_path(@survey.study, @survey), notice: 'Question was deleted.'
   end
 
   private

--- a/app/views/admins/questions/_form.html.erb
+++ b/app/views/admins/questions/_form.html.erb
@@ -11,6 +11,15 @@
 
     <%= render Forms::CheckboxComponent.new(form: f, method: :required, help_text: "Mark this if this question requires a response.") %>
 
-    <%= render Forms::ButtonBarComponent.new(f) %>
+    <div class="flex justify-between items-center">
+      <% if @question.persisted? %>
+        <%= link_to "Delete Question", admin_study_survey_question_path(@survey.study, @survey, @question), class: "oba-btn--danger",
+                    data: { turbo_method: :delete, turbo_confirm: "Are you sure?" } %>
+      <% end %>
+
+      <div class="flex-grow"></div>
+
+      <%= render Forms::ButtonBarComponent.new(f) %>
+    </div>
   </div>
 <% end %>

--- a/spec/requests/admins/questions_spec.rb
+++ b/spec/requests/admins/questions_spec.rb
@@ -37,5 +37,4 @@ RSpec.describe "Admins::Questions", type: :request do
       expect(flash[:notice]).to eq("Question was deleted.")
     end
   end
-
 end

--- a/spec/requests/admins/questions_spec.rb
+++ b/spec/requests/admins/questions_spec.rb
@@ -25,4 +25,17 @@ RSpec.describe "Admins::Questions", type: :request do
       end
     end
   end
+
+  context "DELETE /admin/studies/:study_id/surveys/:survey_id/questions/:id" do
+    let!(:question) { create(:question, survey:) }
+    it "deletes the question" do
+      sign_in admin
+      expect do
+        delete admin_study_survey_question_path(study, survey, question)
+      end.to change(Question, :count).by(-1)
+      expect(response).to redirect_to(admin_study_survey_path(study, survey))
+      expect(flash[:notice]).to eq("Question was deleted.")
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #168 

# Changes Made:

- Added a "Delete Question" button for administrators to remove questions from surveys.
- Added a confirmation message to make sure users really want to delete a question.
- Updated tests to check that the delete feature works correctly.

# Screenshot

![image](https://github.com/user-attachments/assets/df79aa7c-b155-4490-9af0-db0f1b6d8bec)
