### PR TITLE
Surveys: Implement latitude and longitude parameters for survey stop responses

### DIFF
--- a/app/controllers/api/v1/survey_responses_controller.rb
+++ b/app/controllers/api/v1/survey_responses_controller.rb
@@ -6,6 +6,8 @@ class Api::V1::SurveyResponsesController < Api::V1::ApiController
     @survey_response = @survey.survey_responses.build
     @survey_response.user_identifier = params[:user_identifier]
     @survey_response.stop_identifier = params[:stop_identifier]
+    @survey_response.stop_latitude = params[:stop_latitude]
+    @survey_response.stop_longitude = params[:stop_longitude]
 
     responses = JSON.parse(params[:responses]).map { |r| SurveyResponseContent.new(r) }
     @survey_response.upsert_responses(responses)

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -71,7 +71,7 @@ class SurveyResponse < ApplicationRecord
 
   # Generates a CSV header
   def self.csv_header(all_question_labels)
-    ["ID", "User ID", "Stop", "Created"] + all_question_labels
+    ["ID", "User ID", "Stop", "Stop latitude", "Stop longitude", "Created"] + all_question_labels
   end
 
   # Generates a CSV row
@@ -82,6 +82,8 @@ class SurveyResponse < ApplicationRecord
       response.id,
       response.user_identifier,
       response.stop_identifier,
+      response.stop_latitude,
+      response.stop_longitude,
       response.created_at
     ]
 

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -14,6 +14,9 @@ class SurveyResponse < ApplicationRecord
 
   validates :stop_identifier, presence: true, if: -> { survey.require_stop_id_in_response? }
 
+  validates :stop_latitude, presence: true, if: -> { stop_identifier.present? }
+  validates :stop_longitude, presence: true, if: -> { stop_identifier.present? }
+
   after_initialize do
     self.public_identifier ||= SecureRandom.hex(10)
   end

--- a/app/views/admins/survey_responses/index.html.erb
+++ b/app/views/admins/survey_responses/index.html.erb
@@ -10,6 +10,8 @@
   <% c.with_column("ID") %>
   <% c.with_column("User ID") %>
   <% c.with_column("Stop") %>
+  <% c.with_column("Stop latitude") %>
+  <% c.with_column("Stop longitude") %>
   <% c.with_column("Responses") %>
   <% c.with_column("Created") %>
   <% c.with_column("Updated") %>
@@ -24,7 +26,13 @@
           <%= r.user_identifier %>
         </td>
         <td class="oba-td">
-          <%= (r.stop_identifier.blank? || r.stop_identifier == "null") ? "N/A" : r.stop_identifier %>
+          <%= (r.stop_identifier.blank? || r.stop_identifier == "null") ? "N/A" : r.stop_identifier %><br>
+        </td>
+        <td class="oba-td">
+          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_latitude.blank?) ? "N/A" : r.stop_latitude %><br>
+        </td>
+        <td class="oba-td">
+          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_longitude.blank?) ? "N/A" : r.stop_longitude %><br>
         </td>
         <td class="oba-td">
           <%= r.responses.to_json %>

--- a/app/views/admins/survey_responses/index.html.erb
+++ b/app/views/admins/survey_responses/index.html.erb
@@ -29,10 +29,10 @@
           <%= (r.stop_identifier.blank? || r.stop_identifier == "null") ? "N/A" : r.stop_identifier %><br>
         </td>
         <td class="oba-td">
-          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_latitude.blank?) ? "N/A" : r.stop_latitude %><br>
+          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_latitude == 0.0) ? "N/A" : r.stop_latitude %><br>
         </td>
         <td class="oba-td">
-          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_longitude.blank?) ? "N/A" : r.stop_longitude %><br>
+          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_longitude == 0.0) ? "N/A" : r.stop_longitude %><br>
         </td>
         <td class="oba-td">
           <%= r.responses.to_json %>

--- a/app/views/admins/survey_responses/index.html.erb
+++ b/app/views/admins/survey_responses/index.html.erb
@@ -29,10 +29,10 @@
           <%= (r.stop_identifier.blank? || r.stop_identifier == "null") ? "N/A" : r.stop_identifier %><br>
         </td>
         <td class="oba-td">
-          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_latitude == 0.0) ? "N/A" : r.stop_latitude %><br>
+          <%= (r.stop_latitude.blank? || r.stop_latitude == "null" || r.stop_latitude == 0.0) ? "N/A" : r.stop_latitude %><br>
         </td>
         <td class="oba-td">
-          <%= (r.stop_identifier.blank? || r.stop_identifier == "null" || r.stop_longitude == 0.0) ? "N/A" : r.stop_longitude %><br>
+          <%= (r.stop_longitude.blank? || r.stop_longitude == "null" || r.stop_longitude == 0.0) ? "N/A" : r.stop_longitude %><br>
         </td>
         <td class="oba-td">
           <%= r.responses.to_json %>

--- a/db/migrate/20241007194402_add_stop_latitude_and_stop_longitude_to_survey_responses.rb
+++ b/db/migrate/20241007194402_add_stop_latitude_and_stop_longitude_to_survey_responses.rb
@@ -1,0 +1,6 @@
+class AddStopLatitudeAndStopLongitudeToSurveyResponses < ActiveRecord::Migration[7.1]
+  def change
+    add_column :survey_responses, :stop_latitude, :decimal, precision: 15, scale: 10
+    add_column :survey_responses, :stop_longitude, :decimal, precision: 15, scale: 10
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_07_194402) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_07_194402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_23_204512) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_07_194402) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -146,6 +146,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_23_204512) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "stop_identifier"
+    t.decimal "stop_latitude", precision: 15, scale: 10
+    t.decimal "stop_longitude", precision: 15, scale: 10
     t.index ["public_identifier"], name: "index_survey_responses_on_public_identifier", unique: true
     t.index ["stop_identifier"], name: "index_survey_responses_on_stop_identifier"
     t.index ["survey_id"], name: "index_survey_responses_on_survey_id"

--- a/spec/models/survey_response_spec.rb
+++ b/spec/models/survey_response_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
-
 RSpec.describe SurveyResponse, type: :model do
   describe 'validations' do
     it 'is valid with valid attributes' do
@@ -27,6 +26,18 @@ RSpec.describe SurveyResponse, type: :model do
       it 'is valid with a stop_identifier' do
         survey_response = build(:survey_response, stop_latitude: 1.0, stop_longitude: 1.0, stop_identifier: '123')
         expect(survey_response).to be_valid
+      end
+    end
+
+    describe 'validations for stop location latitude and longitude' do
+      it 'is valid when stop_latitude and stop_longitude are present' do
+        survey_response = build(:survey_response, stop_latitude: 1.0, stop_longitude: 1.0, stop_identifier: 'stop_123')
+        expect(survey_response).to be_valid
+      end
+
+      it 'is invalid when stop_latitude and stop_longitude are absent' do
+        survey_response = build(:survey_response, stop_latitude: nil, stop_longitude: nil, stop_identifier: 'stop_123')
+        expect(survey_response).not_to be_valid
       end
     end
   end
@@ -82,41 +93,21 @@ RSpec.describe SurveyResponse, type: :model do
     end
   end
 
-  describe 'validations for stop location latitude and longitude' do
-    it 'is valid when stop_latitude and stop_longitude are present' do
-      survey_response = build(:survey_response, stop_latitude: 1.0, stop_longitude: 1.0, stop_identifier: 'stop_123')
-      expect(survey_response.stop_identifier).to eq('stop_123')
-      expect(survey_response.stop_latitude).to eq(1.0)
-      expect(survey_response.stop_longitude).to eq(1.0)
-      expect(survey_response).to be_valid
-    end
-
-    it 'is invalid when stop_latitude and stop_longitude are absent' do
-      survey_response = build(:survey_response, stop_latitude: nil, stop_longitude: nil, stop_identifier: 'stop_123')
-      expect(survey_response).not_to be_valid
-    end
-  end
-
   describe '.to_csv' do
     let(:survey) { create(:survey) }
-
-    context 'when stop latitude and longitude are present' do
-      it 'includes stop latitude and longitude in the CSV' do
-        survey_response = create(:survey_response, survey:, stop_latitude: 1.0, stop_longitude: 1.0, stop_identifier: 'stop_123')
-        csv = SurveyResponse.to_csv([survey_response])
-        puts csv
-        expect(csv).to include('stop_123')
-        expect(csv).to include('1.0')
-      end
+    it 'includes stop latitude and longitude values in the CSV' do
+      survey_response = create(:survey_response, survey:,
+                                                 stop_latitude: 1.0, stop_longitude: 1.0, stop_identifier: 'stop_123')
+      csv = SurveyResponse.to_csv([survey_response])
+      expect(check_column_value_exists?(csv, "Stop longitude")).to be true
+      expect(check_column_value_exists?(csv, "Stop latitude")).to be true
     end
 
-    context 'when stop latitude and longitude are absent' do
-      it 'does not include stop latitude and longitude in the CSV' do
-        survey_response = create(:survey_response, survey:, stop_latitude: nil, stop_longitude: nil, stop_identifier: nil)
-        csv = SurveyResponse.to_csv([survey_response])
-        expect(csv).not_to include('stop_123')
-        expect(csv).not_to include('1.0')
-      end
+    it 'does not include values for stop latitude and longitude in the CSV' do
+      survey_response = create(:survey_response, survey:, stop_latitude: nil, stop_longitude: nil, stop_identifier: nil)
+      csv = SurveyResponse.to_csv([survey_response])
+      expect(check_column_value_exists?(csv, "Stop longitude")).to be false
+      expect(check_column_value_exists?(csv, "Stop latitude")).to be false
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,4 +35,5 @@ RSpec.configure do |config|
   config.include ApiHelper, type: :request
   config.include RequestHelper, type: :request
   config.include ModelsHelper
+  config.include CsvHelper
 end

--- a/spec/requests/admins/survey_responses_spec.rb
+++ b/spec/requests/admins/survey_responses_spec.rb
@@ -2,6 +2,31 @@ require 'rails_helper'
 
 RSpec.describe "Admins::SurveyResponses", type: :request do
   describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+    let(:region) { create(:region) }
+    let(:admin) { create(:admin, region:) }
+    let(:study) { create(:study, region:) }
+    let(:survey) { create(:survey, study:) }
+
+    before do
+      sign_in admin
+      @response_with_location = create(:survey_response, survey:, stop_latitude: 1.0, stop_longitude: 1.0, stop_identifier: 'stop_123')
+      @response_without_location = create(:survey_response, survey:, stop_latitude: nil, stop_longitude: nil, stop_identifier: nil)
+    end
+
+    it 'renders the index template' do
+      get admin_study_survey_survey_responses_path(study, survey)
+      expect(response).to have_http_status(:ok)
+      expect(response).to render_template(:index)
+    end
+
+    it 'checks the values of the survey responses' do
+      expect(@response_with_location.stop_latitude).to eq(1.0)
+      expect(@response_with_location.stop_longitude).to eq(1.0)
+      expect(@response_with_location.stop_identifier).to eq('stop_123')
+
+      expect(@response_without_location.stop_latitude).to be_nil
+      expect(@response_without_location.stop_longitude).to be_nil
+      expect(@response_without_location.stop_identifier).to be_nil
+    end
   end
 end

--- a/spec/support/csv_helper.rb
+++ b/spec/support/csv_helper.rb
@@ -1,0 +1,20 @@
+module CsvHelper
+  # Checks if the specified column in the given CSV string has a value
+  # in the last row of data.
+  #
+  # @param csv [String] The CSV formatted string containing multiple rows of data.
+  # @param column_name [String] The name of the column to check for values.
+  # @return [Boolean] Returns true if the value in the specified column of the last
+  # row is present (not nil or empty); returns false if the column does not exist
+  # or if the value is absent.
+  def check_column_value_exists?(csv, column_name)
+    csv_lines = csv.split("\n")
+    header = csv_lines.first.split(',')
+
+    column_index = header.index(column_name)
+    return false unless column_index
+
+    value = csv_lines.last.split(',')[column_index]
+    !value.nil? && !value.empty?
+  end
+end


### PR DESCRIPTION
Fixes: #174 and [OneBusAway/onebusaway-android/issues/1259](https://github.com/OneBusAway/onebusaway-android/issues/1259)

## Changes Made

- Updated controllers to handle the new latitude and longitude fields.
- Updated CSV and HTML view to display latitude and longitude data.

## Screenshot

![image](https://github.com/user-attachments/assets/1dfcb293-7677-4c92-8ea7-9495ae56c2b2)
