### PR TITLE
Surveys: Set the required field to false for external surveys and label typed questions

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -5,6 +5,7 @@ class Question < ApplicationRecord
   # survey question content
   include StoreModel::NestedAttributes
 
+  before_validation :set_required_param
   before_save do
     content.prune
   end
@@ -14,6 +15,12 @@ class Question < ApplicationRecord
 
   after_initialize do
     self.content = QuestionContent.new(type: 'text') if new_record? && !content&.has_content?
+  end
+  
+  private
+
+  def set_required_param
+    self.required = false if %w[external_survey label].include?(content&.type)
   end
 end
 

--- a/app/views/admins/questions/_form.html.erb
+++ b/app/views/admins/questions/_form.html.erb
@@ -8,9 +8,9 @@
     <%= f.fields_for :content do |f2| %>
       <%= render partial_for_question(@question), form: f2 %>
     <% end %>
-
-    <%= render Forms::CheckboxComponent.new(form: f, method: :required, help_text: "Mark this if this question requires a response.") %>
-
+    <% unless @question.content.type.in?(%w[external_survey label]) %>
+      <%= render Forms::CheckboxComponent.new(form: f, method: :required, help_text: "Mark this if this question requires a response.") %>
+    <% end %>
     <div class="flex justify-between items-center">
       <% if @question.persisted? %>
         <%= link_to "Delete Question", admin_study_survey_question_path(@survey.study, @survey, @question), class: "oba-btn--danger",

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -16,5 +16,30 @@ RSpec.describe Question, type: :model do
       new_question = Question.new
       expect(new_question.required).to be true
     end
+
+    it 'is false for external_survey type' do
+      new_question = Question.new(
+        survey:,
+        content: QuestionContent.new(
+          type: 'external_survey',
+          label_text: 'Sample Label',
+          survey_provider: 'Provider',
+          url: 'http://example.com',
+          sdk_configuration_values: [],
+          embedded_data_fields: []
+        )
+      )
+      new_question.valid?
+      expect(new_question.required).to be false
+    end
+
+    it 'is false for label type' do
+      new_question = Question.new(
+        survey:,
+        content: QuestionContent.new(type: 'label', label_text: 'Sample Label')
+      )
+      new_question.valid?
+      expect(new_question.required).to be false
+    end
   end
 end


### PR DESCRIPTION
Fixes: #201 

## Key Changes

- The Required checkbox will be hidden when adding a new `external-survey` and `label` questions
- By default `external-survey` and `label` questions `required` field will be false
- Updated tests to cover these edge cases.