### PR TITLE
Surveys: Improve UX for survey visibility options

### DIFF
--- a/app/helpers/admins/surveys_helper.rb
+++ b/app/helpers/admins/surveys_helper.rb
@@ -6,4 +6,23 @@ module Admins::SurveysHelper
       ["SurveyMonkey", "survey_monkey"]
     ]
   end
+
+  # Return a string describing visibility of the survey
+  # @param survey [Survey]
+  # @return [String] the visibility of the survey
+  def survey_visibility(survey)
+    if survey.show_on_map && survey.show_on_stops
+      return "Visible on specific stops and routes" if survey.visible_stop_list.present? && survey.visible_route_list.present?
+      return "Visible on specific stops and map" if survey.visible_stop_list.present?
+      return "Visible on specific routes and map" if survey.visible_route_list.present?
+
+      "Visible on all stops and map"
+    elsif survey.show_on_stops
+      "Visible on all stops"
+    elsif survey.show_on_map
+      "Visible on map"
+    else
+      "Not visible"
+    end
+  end
 end

--- a/app/helpers/admins/surveys_helper.rb
+++ b/app/helpers/admins/surveys_helper.rb
@@ -11,18 +11,38 @@ module Admins::SurveysHelper
   # @param survey [Survey]
   # @return [String] the visibility of the survey
   def survey_visibility(survey)
-    if survey.show_on_map && survey.show_on_stops
-      return "Visible on specific stops and routes" if survey.visible_stop_list.present? && survey.visible_route_list.present?
+    return "Not visible" unless survey.show_on_map || survey.show_on_stops
+
+    if survey.show_on_map
+      handle_map_visibility(survey)
+    elsif survey.show_on_stops
+      handle_stop_visibility(survey)
+    end
+  end
+
+  private
+
+  def handle_map_visibility(survey)
+    if survey.show_on_stops
+      return "Visible on specific stops, routes and map" if survey.visible_stop_list.present? && survey.visible_route_list.present?
       return "Visible on specific stops and map" if survey.visible_stop_list.present?
       return "Visible on specific routes and map" if survey.visible_route_list.present?
 
       "Visible on all stops and map"
-    elsif survey.show_on_stops
-      "Visible on all stops"
-    elsif survey.show_on_map
-      "Visible on map"
     else
-      "Not visible"
+      "Visible on map"
+    end
+  end
+
+  def handle_stop_visibility(survey)
+    if survey.visible_stop_list.present?
+      return "Visible on specific stops and routes" if survey.visible_route_list.present?
+
+      "Visible on specific stops"
+    elsif survey.visible_route_list.present?
+      "Visible on specific routes"
+    else
+      "Visible on all stops"
     end
   end
 end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,4 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
 import "@hotwired/turbo-rails"
 import "controllers"
+import "toggle_stop_and_route"

--- a/app/javascript/toggle_stop_and_route.js
+++ b/app/javascript/toggle_stop_and_route.js
@@ -1,0 +1,18 @@
+document.addEventListener("turbo:load", function () {
+    const showOnStopsCheckbox = document.getElementById('survey_show_on_stops');
+    const visibleStopList = document.getElementById('survey_visible_stop_list');
+    const visibleRouteList = document.getElementById('survey_visible_route_list');
+
+    function toggleStopAndRouteLists() {
+        const isDisabled = !showOnStopsCheckbox.checked;
+        visibleStopList.disabled = isDisabled;
+        visibleRouteList.disabled = isDisabled;
+
+        visibleStopList.style.opacity = isDisabled ? '0.5' : '1';
+        visibleRouteList.style.opacity = isDisabled ? '0.5' : '1';
+    }
+
+    toggleStopAndRouteLists();
+
+    showOnStopsCheckbox.addEventListener('change', toggleStopAndRouteLists);
+});

--- a/app/views/admins/surveys/_form.html.erb
+++ b/app/views/admins/surveys/_form.html.erb
@@ -44,3 +44,4 @@
     <%= render Forms::ButtonBarComponent.new(f) %>
   </div>
 <% end %>
+<%= javascript_include_tag 'toggle_stop_and_route' %>

--- a/app/views/admins/surveys/show.html.erb
+++ b/app/views/admins/surveys/show.html.erb
@@ -18,6 +18,7 @@
           { name: "Show on Map", value: @survey.show_on_map? ? "Yes" : "No" },
           { name: "Show on Stops", value: @survey.show_on_stops? ? "Yes" : "No" },
           { name: "Require stop ID in responses", value: @survey.require_stop_id_in_response? ? "Yes" : "No" },
+          { name: "Visibility", value: survey_visibility(@survey) },
           {
             name: "Visible stop list",
             value: (@survey.show_on_stops && @survey.visible_stop_list.present?) ? @survey.visible_stop_list : "N/A"
@@ -26,7 +27,6 @@
             name: "Visible route list",
             value: (@survey.show_on_stops && @survey.visible_route_list.present?) ? @survey.visible_route_list : "N/A"
           },
-          { name: "Survey visibility", value: survey_visibility(@survey) },
           { name: "Start Date", value: @survey.start_date },
           { name: "End Date", value: @survey.end_date }
         ]

--- a/app/views/admins/surveys/show.html.erb
+++ b/app/views/admins/surveys/show.html.erb
@@ -18,8 +18,14 @@
           { name: "Show on Map", value: @survey.show_on_map? ? "Yes" : "No" },
           { name: "Show on Stops", value: @survey.show_on_stops? ? "Yes" : "No" },
           { name: "Require stop ID in responses", value: @survey.require_stop_id_in_response? ? "Yes" : "No" },
-          { name: "Visible stop list", value: @survey.visible_stop_list },
-          { name: "Visible route list", value: @survey.visible_route_list },
+          {
+            name: "Visible stop list",
+            value: (@survey.show_on_stops && @survey.visible_stop_list.present?) ? @survey.visible_stop_list : "N/A"
+          },
+          {
+            name: "Visible route list",
+            value: (@survey.show_on_stops && @survey.visible_route_list.present?) ? @survey.visible_route_list : "N/A"
+          },
           { name: "Survey visibility", value: survey_visibility(@survey) },
           { name: "Start Date", value: @survey.start_date },
           { name: "End Date", value: @survey.end_date }

--- a/app/views/admins/surveys/show.html.erb
+++ b/app/views/admins/surveys/show.html.erb
@@ -20,6 +20,7 @@
           { name: "Require stop ID in responses", value: @survey.require_stop_id_in_response? ? "Yes" : "No" },
           { name: "Visible stop list", value: @survey.visible_stop_list },
           { name: "Visible route list", value: @survey.visible_route_list },
+          { name: "Survey visibility", value: survey_visibility(@survey) },
           { name: "Start Date", value: @survey.start_date },
           { name: "End Date", value: @survey.end_date }
         ]

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -14,3 +14,4 @@ pin "tailwindcss/plugin", to: "tailwindcss--plugin.js" # @3.4.3
 pin "@rails/request.js", to: "@rails--request.js.js" # @0.0.8
 pin "@stimulus-components/sortable", to: "@stimulus-components--sortable.js" # @5.0.1
 pin "sortablejs" # @1.15.2
+pin "toggle_stop_and_route", to: "toggle_stop_and_route.js"


### PR DESCRIPTION
## Description

This PR introduces enhanced logic for the visibility of surveys based on their configuration options.
## Changes Made

### Visibility Logic: 

Conditional checks were added for the visibility of the stop and route lists based on the `show_on_stops` property of the survey. 

 The following visibility states have been implemented:
   - **Visible on all stops and map**: when both `show_on_stops` and `show_on_maps` are true and `visible_route_list` and `visible_stops_list` are empty.
   - **Visible on specific stops, routes and map**: When both `visible_stop_list` and `visible_route_list` are present and `show_on_stops` is true and `show_on_map` is true.
   - **Visible on specific stops and routes**: When both `visible_stop_list` and `visible_route_list` are present and `show_on_stops` is true.
  - **Visible on specific stops**: When only `visible_stop_list` is present and `show_on_stops` is true.
  - **Visible on specific routes**: When only `visible_route_list` is present and `show_on_stops` is true.
  - **Visible on all stops**: When `show_on_stops` is true but both lists are empty.
  - **Visible on map**: When `show_on_map` is true without any further conditions.
  - **Not visible**: When both `show_on_stops` and `show_on_map` are false.

### Updated UI Components:

- The data list component rendering now includes visibility states, showing "N/A" when the lists are not applicable based on `show_on_stops` state

### Disabled route and stops list

1. Implemented functionality to disable the route and stops lists based on the `show_on_stops` property of the survey.
2. When the `show_on_stops` checkbox is unchecked, both the route and stops lists are disabled and visually indicated as such.

